### PR TITLE
do not use CFLAGS on C++ objects

### DIFF
--- a/Makefile.lib
+++ b/Makefile.lib
@@ -399,47 +399,47 @@ disp_distclean        = $($(verbose)_disp_distclean)
 #
 # _CMD
 #
-_cmd_depend.c       = $(CC) $(CFLAGS) $(CXXFLAGS) $($1_cflags) $($1_cxxflags) \
+_cmd_depend.c       = $(CC) $(CFLAGS) $($1_cflags) $($1_cxxflags) \
                       $($1_includes) -M $$< | $(SED) 's,\($$*\.o\) *:,.$1/\1 \
                       $$@: ,' > $$@; \
                       $(CP) $$@ $$@.p; \
                       $(SED) -e 's/\#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$$$//' -e '/^$$$$/ d' -e 's/$$$$/ :/' < $$@ >> $$@.p; \
                       $(MV) $$@.p $$@
-_cmd_compile.c      = $(CC) $(CFLAGS) $(CXXFLAGS) $($1_cflags) $($1_cxxflags) \
+_cmd_compile.c      = $(CC) $(CFLAGS) $($1_cflags) $($1_cxxflags) \
                       $($1_includes) $$($1_$$<_cflags-y) $$($1_$$<_cxxflags-y) -c -o $$@ $$<
-_cmd_link.c         = $(CC) $(CFLAGS) $(CXXFLAGS) $($1_libraries) -o $$@ $$(filter-out __FORCE $($1_depends-y),$$^) \
+_cmd_link.c         = $(CC) $(CFLAGS) $($1_libraries) -o $$@ $$(filter-out __FORCE $($1_depends-y),$$^) \
                       $($1_ldflags) $(LDFLAGS)
-_cmd_link_so.c      = $(CC) $(CFLAGS) $(CXXFLAGS) $($1_libraries) -o $$@ $$(filter-out __FORCE $($1_depends-y),$$^) \
+_cmd_link_so.c      = $(CC) $(CFLAGS) $($1_libraries) -o $$@ $$(filter-out __FORCE $($1_depends-y),$$^) \
                       $($1_ldflags) $$(filter-out -static,$(LDFLAGS)) -shared
 
-_cmd_depend.c.host  = $(HOSTCC) $(CFLAGS) $(CXXFLAGS) $($1_cflags) \
+_cmd_depend.c.host  = $(HOSTCC) $(CFLAGS) $($1_cflags) \
                       $($1_cxxflags) $($1_includes) -M $$< | $(SED) \
                       's,\($$*\.o\) *:,.$1/\1 $$@: ,' > $$@
-_cmd_compile.c.host = $(HOSTCC) $(CFLAGS) $(CXXFLAGS) $($1_cflags) \
+_cmd_compile.c.host = $(HOSTCC) $(CFLAGS) $($1_cflags) \
                       $($1_cxxflags) $($1_includes) $$($1_$$<_cflags-y) -c -o $$@ $$<
-_cmd_link.c.host    = $(HOSTCC) $(CFLAGS) $(CXXFLAGS) $($1_libraries) -o $$@ $$(filter-out __FORCE $($1_depends-y),$$^) \
+_cmd_link.c.host    = $(HOSTCC) $(CFLAGS) $($1_libraries) -o $$@ $$(filter-out __FORCE $($1_depends-y),$$^) \
                       $($1_ldflags) $(LDFLAGS)
-_cmd_link_so.c.host = $(HOSTCC) $(CFLAGS) $(CXXFLAGS) $($1_libraries) -o $$@ $$(filter-out __FORCE $($1_depends-y),$$^) \
+_cmd_link_so.c.host = $(HOSTCC) $(CFLAGS) $($1_libraries) -o $$@ $$(filter-out __FORCE $($1_depends-y),$$^) \
                       $($1_ldflags) $$(filter-out -static,$(LDFLAGS)) -shared
 
-_cmd_depend.cxx       = $(CXX) $(CFLAGS) $(CXXFLAGS) $($1_cflags) $($1_cxxflags) \
+_cmd_depend.cxx       = $(CXX) $(CXXFLAGS) $($1_cflags) $($1_cxxflags) \
                         $($1_includes) -M $$< | $(SED) 's,\($$*\.o\) *:,.$1/\1 \
                         $$@: ,' > $$@
-_cmd_compile.cxx      = $(CXX) $(CFLAGS) $(CXXFLAGS) $($1_cflags) $($1_cxxflags) \
+_cmd_compile.cxx      = $(CXX) $(CXXFLAGS) $($1_cflags) $($1_cxxflags) \
                         $($1_includes) $$($1_$$<_cflags-y) $$($1_$$<_cxxflags-y) -c -o $$@ $$<
-_cmd_link.cxx         = $(CXX) $(CFLAGS) $(CXXFLAGS) $($1_libraries) -o $$@ $$(filter-out __FORCE $($1_depends-y),$$^) \
+_cmd_link.cxx         = $(CXX) $(CXXFLAGS) $($1_libraries) -o $$@ $$(filter-out __FORCE $($1_depends-y),$$^) \
                         $($1_ldflags) $(LDFLAGS)
-_cmd_link_so.cxx      = $(CXX) $(CFLAGS) $(CXXFLAGS) $($1_libraries) -o $$@ $$(filter-out __FORCE $($1_depends-y),$$^) \
+_cmd_link_so.cxx      = $(CXX) $(CXXFLAGS) $($1_libraries) -o $$@ $$(filter-out __FORCE $($1_depends-y),$$^) \
                         $($1_ldflags) $$(filter-out -static,$(LDFLAGS)) -shared
 
-_cmd_depend.cxx.host  = $(HOSTCXX) $(CFLAGS) $(CXXFLAGS) $($1_cflags) \
+_cmd_depend.cxx.host  = $(HOSTCXX) $(CXXFLAGS) $($1_cflags) \
                         $($1_cxxflags) $($1_includes) -M $$< | $(SED) \
                         's,\($$*\.o\) *:,.$1/\1 $$@: ,' > $$@
-_cmd_compile.cxx.host = $(HOSTCXX) $(CFLAGS) $(CXXFLAGS) $($1_cflags) \
+_cmd_compile.cxx.host = $(HOSTCXX) $(CXXFLAGS) $($1_cflags) \
                         $($1_cxxflags) $($1_includes) $$($1_$$<_cxxflags-y) -c -o $$@ $$<
-_cmd_link.cxx.host    = $(HOSTCXX) $(CFLAGS) $(CXXFLAGS) $($1_libraries) -o $$@ $$(filter-out __FORCE $($1_depends-y),$$^) \
+_cmd_link.cxx.host    = $(HOSTCXX) $(CXXFLAGS) $($1_libraries) -o $$@ $$(filter-out __FORCE $($1_depends-y),$$^) \
                         $($1_ldflags) $(LDFLAGS)
-_cmd_link_so.cxx.host = $(HOSTCXX) $(CFLAGS) $(CXXFLAGS) $($1_libraries) -o $$@ $$(filter-out __FORCE $($1_depends-y),$$^) \
+_cmd_link_so.cxx.host = $(HOSTCXX) $(CXXFLAGS) $($1_libraries) -o $$@ $$(filter-out __FORCE $($1_depends-y),$$^) \
                         $($1_ldflags) $$(filter-out -static,$(LDFLAGS)) -shared
 
 _cmd_moc.cxx          = $(MOC) $$< -o $$@


### PR DESCRIPTION
Combining C and C++ objects under same target is not possible
if you're using C only parameters with CFLAGS like -std=c99

This commit disable the use of CFLAGS on C++ objects, you need
to use CXXFLAGS.