### PR TITLE
fix parallel compilation with dist.dir

### DIFF
--- a/Makefile.lib
+++ b/Makefile.lib
@@ -1,8 +1,8 @@
 #
 # Makefile.lib
 #
-# version   : 3.2.0
-# copyright : 2002 - 2019 by Alper Akcan
+# version   : 3.2.1
+# copyright : 2002 - 2020 by Alper Akcan
 # email     : alper.akcan@gmail.com
 #
 # This library is free software; you can redistribute it and/or
@@ -50,6 +50,7 @@
 #   20190701 - do not override depends-y
 #   20190702 - fix depends-y for subdirs
 #   20190806 - fix parallel compilation of ${target}_depends-y
+#   20200117 - fix parallel compilation with dist.dir
 
 #
 # Example
@@ -274,12 +275,12 @@ pur_objects = $$(subst __UPDIR__/,../,$(CURDIR)/$$@)
 #
 # PUR
 #
-pur_disp_depend.c         = echo "  CPP        $(pur_objects)"
+pur_disp_depend.c         = echo "  DEP        $(pur_objects)"
 pur_disp_compile.c        = echo "  CC         $(pur_objects)"
 pur_disp_link.c           = echo "  LINK       $(pur_objects)"
 pur_disp_link_so.c        = echo "  LINKSO     $(pur_objects)"
 
-pur_disp_depend.cxx       = echo "  CPP        $(pur_objects)"
+pur_disp_depend.cxx       = echo "  DEP        $(pur_objects)"
 pur_disp_compile.cxx      = echo "  CXX        $(pur_objects)"
 pur_disp_link.cxx         = echo "  LINK       $(pur_objects)"
 pur_disp_link_so.cxx      = echo "  LINKSO     $(pur_objects)"
@@ -287,17 +288,17 @@ pur_disp_link_so.cxx      = echo "  LINKSO     $(pur_objects)"
 pur_disp_moc.qt           = echo "  MOC        $(pur_objects)"
 pur_disp_uic.qt           = echo "  UIC        $(pur_objects)"
 
-pur_disp_depend.m         = echo "  CPP        $(pur_objects)"
+pur_disp_depend.m         = echo "  DEP        $(pur_objects)"
 pur_disp_compile.m        = echo "  CC         $(pur_objects)"
 pur_disp_link.m           = echo "  LINK       $(pur_objects)"
 pur_disp_link_so.m        = echo "  LINKSO     $(pur_objects)"
 
-pur_disp_depend.c.host    = echo "  HOSTCPP    $(pur_objects)"
+pur_disp_depend.c.host    = echo "  HOSTDEP    $(pur_objects)"
 pur_disp_compile.c.host   = echo "  HOSTCC     $(pur_objects)"
 pur_disp_link.c.host      = echo "  HOSTLINK   $(pur_objects)"
 pur_disp_link_so.c.host   = echo "  HOSTLINKSO $(pur_objects)"
 
-pur_disp_depend.cxx.host  = echo "  HOSTCPP    $(pur_objects)"
+pur_disp_depend.cxx.host  = echo "  HOSTDEP    $(pur_objects)"
 pur_disp_compile.cxx.host = echo "  HOSTCXX    $(pur_objects)"
 pur_disp_link.cxx.host    = echo "  HOSTLINK   $(pur_objects)"
 pur_disp_link_so.cxx.host = echo "  HOSTLINKSO $(pur_objects)"
@@ -305,7 +306,7 @@ pur_disp_link_so.cxx.host = echo "  HOSTLINKSO $(pur_objects)"
 pur_disp_moc.qt.host      = echo "  HOSTMOC    $(pur_objects)"
 pur_disp_uic.qt.host      = echo "  HOSTUIC    $(pur_objects)"
 
-pur_disp_depend.m.host    = echo "  HOSTCPP    $(pur_objects)"
+pur_disp_depend.m.host    = echo "  HOSTDEP    $(pur_objects)"
 pur_disp_compile.m.host   = echo "  HOSTCC     $(pur_objects)"
 pur_disp_link.m.host      = echo "  HOSTLINK   $(pur_objects)"
 pur_disp_link_so.m.host   = echo "  HOSTLINKSO $(pur_objects)"
@@ -989,13 +990,16 @@ $(eval $(foreach D,$(dist.include-y), $(eval $(call dist.include-variables,$D)))
 $(eval $(foreach D,$(dist.share-y), $(eval $(call dist.share-variables,$D))))
 endif
 
+dist_all: $(target-dists)
+	@true
+
 # generic tags
 
 all: $(addsuffix _all, $(subdirs))
 all: $(target-builds)
-all: $(target-dists)
 all: $(target.extra-y)
 all: __FORCE
+	@$(MAKE) dist_all
 	@true
 
 clean: $(addsuffix _clean, $(subdir-y) $(subdir-n) $(subdir-))


### PR DESCRIPTION
$(target-builds) and $(target-dists) gets in parallel and make trys to dist the binaries before they are created. This commit fixes the problem.